### PR TITLE
Moved cart item input into Cart class

### DIFF
--- a/frontend_app/admin_cart.py
+++ b/frontend_app/admin_cart.py
@@ -11,9 +11,7 @@ class AdminCart(Cart):
         super().__init__(cart_owner)
         self.restock_btn = None
 
-    def render(self):
-        self.table = ui.table(columns=self.columns, rows=self.rows)
-
+    def render_btns(self) -> None:
         with ui.row():
             # checkout button
             self.checkout_btn = ui.button('Checkout')
@@ -22,6 +20,12 @@ class AdminCart(Cart):
             # restock button
             self.restock_btn = ui.button('Restock')
             self.restock_btn.on_click(lambda: self.restock())
+
+    def set_quantity_max(self, ignored: str) -> None:
+        """
+        For admins, this is set to infinity for all items.
+        """
+        self.quantity_select.max = float('inf')
 
     def restock(self):
         # convert cart items to item requests

--- a/frontend_app/cart.py
+++ b/frontend_app/cart.py
@@ -1,4 +1,5 @@
 import json
+from typing import Self
 
 from nicegui import ui, app
 from pydantic import BaseModel
@@ -69,7 +70,7 @@ class Cart:
         if self.name_in is not None:
             self.name_in.set_autocomplete(list(self.name_max_map.keys()))
 
-    def render(self) -> None:
+    def render(self) -> Self:
         """
         Render this cart on the page. The cart will automatically be updated when items are added.
         """
@@ -77,6 +78,7 @@ class Cart:
         self.table = ui.table(columns=self.columns, rows=self.rows)
         self.render_item_input()
         self.render_btns()
+        return self
 
     def set_quantity_max(self, item_name: str) -> None:
         """

--- a/frontend_app/cart.py
+++ b/frontend_app/cart.py
@@ -1,13 +1,13 @@
 import json
 
-from nicegui import ui
+from nicegui import ui, app
 from pydantic import BaseModel
 from starlette.responses import JSONResponse
 
-from frontend_app.inventory import invalidate_inventory
+from frontend_app.inventory import invalidate_inventory, INV_VALID_FLAG
 from models.request_schemas import ItemRequest, MultiItemRequest
 from models.response_schemas import MessageResponse
-from server import checkout_item, db_context
+from server import checkout_item, db_context, get_items
 
 
 class CartItem(BaseModel):
@@ -30,22 +30,97 @@ class Cart:
     checkout_btn: ui.button
     cart_owner: str | None
 
+    name_max_map: dict[str, int]
+    name_id_map: dict[str, int]
+    name_in: ui.input
+    quantity_select: ui.number
+
     def __init__(self, cart_owner=None):
         self.columns = [
-                        #{'id': 'id', 'label': 'ID', 'field': 'id'},
-                        {'name': 'name', 'label': 'Name', 'field': 'name'},
-                        {'name': 'quantity', 'label': 'Quantity', 'field': 'quantity'}
-                        ]
+            # {'id': 'id', 'label': 'ID', 'field': 'id'},
+            {'name': 'name', 'label': 'Name', 'field': 'name'},
+            {'name': 'quantity', 'label': 'Quantity', 'field': 'quantity'}
+        ]
         self.rows = []
         self.table = None
         self.checkout_btn = None
         self.cart_owner = cart_owner
 
+        self.name_max_map = {}
+        self.name_id_map = {}
+        self.name_in = None
+        self.quantity_select = None
+
+        # when the inventory is invalidated, update the name_max_map and name_id_map
+        app.storage.general.on_change(lambda e: update_event(e))
+
+        def update_event(event):
+            if INV_VALID_FLAG in event.sender:
+                self.update()
+
+    def update(self) -> None:
+        """
+        Updates the cart with the current items in the database.
+        """
+        with db_context() as db:
+            items = get_items(db)
+        self.name_max_map = {item.name: item.max_checkout for item in items}
+        self.name_id_map = {item.name: item.id for item in items}
+        if self.name_in is not None:
+            self.name_in.set_autocomplete(list(self.name_max_map.keys()))
+
     def render(self) -> None:
         """
         Render this cart on the page. The cart will automatically be updated when items are added.
         """
+        self.update()
         self.table = ui.table(columns=self.columns, rows=self.rows)
+        self.render_item_input()
+        self.render_btns()
+
+    def set_quantity_max(self, item_name: str) -> None:
+        """
+        Sets the max quantity for the item input based on the item name.
+        :param item_name: The name of the item to set the max quantity for.
+        """
+        self.quantity_select.max = self.name_max_map.get(item_name, 0)
+
+    def render_item_input(self) -> None:
+        """
+        Renders the item input for the cart. This is a text input for the item name and a number input for the quantity,
+        along with a button to add the item to the cart.
+        """
+        with ui.row():
+            # adds the name text input which checks if each name is actually an item
+            self.name_in = ui.input(label='Product Name', autocomplete=list(self.name_max_map.keys()),
+                                    validation=lambda item:
+                                    None if item in self.name_max_map.keys()
+                                    else 'Unknown Product')
+
+            # adds the quantity selector and ensures that quantity is a positive integer
+            self.quantity_select = ui.number(label='Quantity', max=0, min=0, value=0,
+                                             validation=lambda quantity:
+                                             None if isinstance(quantity, int) or quantity.is_integer()
+                                             else 'Quantity must be an integer').classes('w-10')
+
+            # and only enables the quantity selector if the item typed in is valid
+            self.quantity_select.bind_enabled_from(self.name_in, 'error', lambda e: e is None)
+            # and sets the max quantity to the max checkout quantity of the item typed in
+            self.name_in.on_value_change(lambda e: self.set_quantity_max(e.value))
+
+            add_btn = ui.button('Add to Cart')
+            add_btn.bind_enabled_from(self.quantity_select)
+
+            add_btn.on_click(lambda: self.add_to_cart(
+                CartItem(id=self.name_id_map.get(self.name_in.value, 0),
+                         name=self.name_in.value,
+                         quantity=int(self.quantity_select.value),
+                         max_checkout=self.name_max_map[self.name_in.value])))
+
+    def render_btns(self) -> None:
+        """
+        Renders the buttons for the cart, excluding the item input.
+        """
         self.checkout_btn = ui.button('Checkout')
         self.checkout_btn.on_click(lambda: self.checkout())
 
@@ -71,6 +146,9 @@ class Cart:
                 self.table.update()
 
     def checkout(self):
+        """
+
+        """
         # convert cart items to item requests
         requests = []
         for item in self.rows:

--- a/frontend_app/common.py
+++ b/frontend_app/common.py
@@ -3,7 +3,7 @@ from frontend_app.cart import Cart
 from frontend_app.inventory import Inventory
 
 
-def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart:
+def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart | AdminCart:
     """
     Creates a cart and displays it.
     :param cart_owner: The student ID of the cart owner, to be used in checkout.
@@ -14,12 +14,11 @@ def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart:
     else:
         cart = AdminCart(cart_owner=cart_owner)
 
-    cart.render()
-    return cart
+    return cart.render()
 
 
-def show_inventory() -> None:
+def show_inventory() -> Inventory:
     """
     Displays all items in the inventory, along with their current stock.
     """
-    Inventory().render()
+    return Inventory().render()

--- a/frontend_app/common.py
+++ b/frontend_app/common.py
@@ -1,9 +1,6 @@
-from nicegui import ui
-
 from frontend_app.admin_cart import AdminCart
-from frontend_app.cart import Cart, CartItem
+from frontend_app.cart import Cart
 from frontend_app.inventory import Inventory
-from server import db_context, get_items
 
 
 def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart:
@@ -12,49 +9,10 @@ def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart:
     :param cart_owner: The student ID of the cart owner, to be used in checkout.
     :param is_admin: If the cart is an admin cart or not
     """
-
-    def set_max(item_name: str) -> None:
-
-        if not is_admin:
-            quantity_select.max = name_max_map.get(item_name, 0)
-        elif is_admin:
-            quantity_select.max = float('inf')
-
-    with db_context() as db:
-        items = get_items(db)
-
-    name_max_map = {item.name: item.max_checkout for item in items}
-    name_id_map = {item.name: item.id for item in items}
-
     if not is_admin:
         cart = Cart(cart_owner=cart_owner)
     else:
         cart = AdminCart(cart_owner=cart_owner)
-
-    with ui.row():
-        # adds the name text input which checks if each name is actually an item
-        name = ui.input(label='Product Name', autocomplete=list(name_max_map.keys()),
-                        validation=lambda item:
-                        None if item in name_max_map.keys()
-                        else 'Unknown Product')
-
-        # adds the quantity selector and ensures that quantity is a positive integer
-        quantity_select = ui.number(label='Quantity', max=0, min=0, value=0,
-                                    validation=lambda quantity:
-                                    None if isinstance(quantity, int) or quantity.is_integer()
-                                    else 'Quantity must be an integer').classes('w-10')
-
-        # and only enables the quantity selector if the item typed in is valid
-        quantity_select.bind_enabled_from(name, 'error', lambda e: e is None)
-        # and sets the max quantity to the max checkout quantity of the item typed in
-        name.on_value_change(lambda e: set_max(e.value))
-
-        add_btn = ui.button('Add to Cart')
-        add_btn.bind_enabled_from(quantity_select)
-
-        add_btn.on_click(lambda: cart.add_to_cart(
-            CartItem(id=name_id_map[name.value], name=name.value, quantity=int(quantity_select.value),
-                     max_checkout=name_max_map[name.value])))
 
     cart.render()
     return cart

--- a/frontend_app/inventory.py
+++ b/frontend_app/inventory.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from nicegui import ui, app
 from nicegui.functions.update import update
 
@@ -9,7 +11,7 @@ INV_VALID_FLAG = 'inv_valid'
 class Inventory:
     table: ui.table
 
-    def render(self):
+    def render(self) -> Self:
         """
         Displays all items in the inventory, along with their current stock.
         """
@@ -38,6 +40,8 @@ class Inventory:
         def refresh(event):
             if INV_VALID_FLAG in event.sender:
                 update(self)
+
+        return self
 
     def update(self):
         if self.table is not None:


### PR DESCRIPTION
- Item input is moved from common.py to cart.py (and admin_cart.py) 
- Newly created items can now be added to the cart immediately after creation without requiring a restart
- render() in Cart and Inventory now return self 