### PR TITLE
Created capability to add 1 (one) item in cart to database when restock

### DIFF
--- a/form_io/form_io.py
+++ b/form_io/form_io.py
@@ -60,7 +60,7 @@ def read_csv(csvfile):
 def read_excel(xlsxfile):
 
     # first detect if the first row is a header
-    # simpler hacky algorithm... just detect if there are no integers
+    # simpler hacky algorithm... just detect if there are no integers in the first row
     header_detected = True
     first_line = pd.read_excel(xlsxfile, header=None, nrows=1)
     for cell in first_line.values.tolist()[0]:

--- a/frontend_app/common.py
+++ b/frontend_app/common.py
@@ -1,28 +1,74 @@
-from frontend_app.admin_cart import AdminCart
-from frontend_app.cart import Cart
-from frontend_app.inventory import Inventory
+from nicegui import APIRouter, ui, app
+from starlette.responses import JSONResponse
+from fastapi import Response
+import json
+
+from models.request_schemas import CreateRequest
+from models.response_schemas import MessageResponse
+from server import db_context, create_item
+from frontend_app.inventory import Inventory, invalidate_inventory
 
 # for button/color theming
 BTN_MAIN = 'btn_main_color'
 # for the admin message board
 ADMIN_MSG = 'admin_board_message'
 
-def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart | AdminCart:
-    """
-    Creates a cart and displays it.
-    :param cart_owner: The student ID of the cart owner, to be used in checkout.
-    :param is_admin: If the cart is an admin cart or not
-    """
-    if not is_admin:
-        cart = Cart(cart_owner=cart_owner)
-    else:
-        cart = AdminCart(cart_owner=cart_owner)
+#def show_cart(cart_owner: str | None = None, is_admin: bool = False) -> Cart | AdminCart:
+#    """
+#    Creates a cart and displays it.
+#    :param cart_owner: The student ID of the cart owner, to be used in checkout.
+#    :param is_admin: If the cart is an admin cart or not
+#    """
+#    if not is_admin:
+#        cart = Cart(cart_owner=cart_owner)
+#    else:
+#        cart = AdminCart(cart_owner=cart_owner)
+#
+#    return cart.render()
 
-    return cart.render()
+
+#def show_inventory() -> Inventory:
+#    """
+#    Displays all items in the inventory, along with their current stock.
+#    """
+#    return Inventory().render()
+
+def valid_input(name: str, amt: int, max: int) -> bool:
+    # to check all potential input values for validity whenever one is changed
+    # TODO: validation directly in inputs? (next sprint?)
+
+    if name is None or len(name.strip()) <= 0:
+        return False
+
+    if amt is None or amt <= 0:
+        return False
+
+    if max is None or max <= 0:
+        return False
+
+    return True
 
 
-def show_inventory() -> Inventory:
-    """
-    Displays all items in the inventory, along with their current stock.
-    """
-    return Inventory().render()
+def make_item(name: str, amt: int, max: int):
+    # add new item to the database
+    with db_context() as db:
+        # attempt to add item to database
+        form_name = name.strip().upper()
+        result = create_item(CreateRequest(name=form_name, initial_stock=amt, max_checkout=max),
+                             Response(), db=db)
+
+        # display popup for success or failure
+        if isinstance(result, MessageResponse):
+            # success
+            with ui.dialog() as dialog, ui.card():
+                ui.label(result.message)
+                ui.button("Close", on_click=dialog.close)
+            dialog.open()
+        elif isinstance(result, JSONResponse):
+            # failure (item already exists)
+            with ui.dialog() as dialog, ui.card():
+                ui.label(f"Error {result.status_code}: {json.loads(result.body.decode())["message"]}")
+                ui.button("Close", on_click=dialog.close)
+            dialog.open()
+
+        invalidate_inventory()

--- a/frontend_app/screens/admin.py
+++ b/frontend_app/screens/admin.py
@@ -7,8 +7,9 @@ from starlette.responses import JSONResponse
 import server
 from frontend_app.analytics import AnalyticsRequest
 from frontend_app.cart import CartItem
-from frontend_app.common import show_inventory, show_cart, BTN_MAIN, ADMIN_MSG
-from frontend_app.inventory import invalidate_inventory, STUDENT_VISIBLE
+from frontend_app.admin_cart import AdminCart
+from frontend_app.common import valid_input, make_item, BTN_MAIN, ADMIN_MSG
+from frontend_app.inventory import Inventory, invalidate_inventory, STUDENT_VISIBLE
 
 from models.request_schemas import CreateRequest
 from models.response_schemas import MessageResponse
@@ -39,10 +40,11 @@ def admin_page():
     # inventory
     with ui.card():
         ui.switch(text='Toggle Student Inventory View').bind_value(app.storage.general, STUDENT_VISIBLE)
-        show_inventory()
+        Inventory().render()
 
         with ui.expansion("Cart", value=True):
-            curr_cart = show_cart('admin', True)
+            curr_cart = AdminCart(cart_owner=None)
+            curr_cart.render()
 
 
     # creating and importing
@@ -109,6 +111,7 @@ def admin_page():
                                        lambda v:v)
 
 
+            
 @router.page('/analytics')
 def analytics_page():
     ui.button('Home Page', on_click=lambda: ui.navigate.to('/admin'))
@@ -173,7 +176,7 @@ def import_file(dest_cart, e):
 
     # now put the data into CartItems
     for row in data:
-        dest_cart.add_to_cart(CartItem(id=1337, name=row[0], quantity=int(row[1]), max_checkout=12))
+        dest_cart.add_to_cart(CartItem(id=1337, name=row[0].upper(), quantity=int(row[1]), max_checkout=12))
 
 def import_text(dest_cart, text):
     # first parse text to extract its data
@@ -184,10 +187,11 @@ def import_text(dest_cart, text):
     data = form_io.read_csv(StringIO(text))
     # now put the data into CartItems
     for row in data:
-        dest_cart.add_to_cart(CartItem(id=1337, name=row[0], quantity=int(row[1]), max_checkout=12))
+        dest_cart.add_to_cart(CartItem(id=1337, name=row[0].upper(), quantity=int(row[1]), max_checkout=12))
     print("\nDATA=\n", data)
-    
 
+
+    
 def export_file(which_file):
     # dummy function for now, for exporting spreadsheet
     ui.notify(f"FILE SENT ({which_file})", close_button="close")

--- a/frontend_app/screens/student.py
+++ b/frontend_app/screens/student.py
@@ -1,8 +1,8 @@
 from nicegui import APIRouter, ui, app
 
-from frontend_app.common import show_inventory, show_cart
-from frontend_app.inventory import STUDENT_VISIBLE
+from frontend_app.inventory import Inventory, STUDENT_VISIBLE
 from frontend_app.common import BTN_MAIN
+from frontend_app.cart import Cart
 
 router = APIRouter(prefix='/student')
 
@@ -20,6 +20,7 @@ def student_page(student_id: str):
     # functionality
     with ui.card():
         with ui.element().bind_visibility(app.storage.general, STUDENT_VISIBLE):
-            show_inventory()
+            Inventory().render()
         with ui.expansion("CART", value=True):
-            show_cart(student_id)
+            cart = Cart(cart_owner=student_id)
+            cart.render()


### PR DESCRIPTION
When you upload a form for example, it may put an item into the cart despite it not yet existing in the database. This allows 1 (one) item from the cart to be added to the database by prompting the user if they want to do so.